### PR TITLE
Fixes for add piece image mapping and duplicates

### DIFF
--- a/MobileOgelUI/ViewModel/LegoPieceViewModel.swift
+++ b/MobileOgelUI/ViewModel/LegoPieceViewModel.swift
@@ -31,11 +31,27 @@ import Observation
         return legoPieces
     }
     
-    func addNewPiece(imageName: String, pieceName: String, quantity: Int, color: LegoColour) {
-        //TODO: check if image name exists.. for now since there is no standard to the image names added we will use the missing icon
-        let newPiece = LegoPiece(imageName: "missing_pieces_icon", pieceName: pieceName, quantity: quantity, officialColour: color)
-        legoPieces.append(newPiece)
-        LegoPieceDBManager.shared.addPiece(piece: newPiece)
+    func addNewPiece(imageName: String, pieceName: String, quantity: Int, colour: LegoColour) {
+        
+        // to prevent duplicate pieces showing separatley
+        if let existingPieceIndex = legoPieces.firstIndex(where: { $0.pieceName == pieceName && $0.officialColour == colour }) {
+            legoPieces[existingPieceIndex].quantity += quantity
+            
+            LegoPieceDBManager.shared.updatePiece(name: pieceName, newQuantity: quantity)
+        } else {
+            let storedImage = imageName + "_" + String(describing: colour)
+            
+            let newPiece = LegoPiece(
+                imageName: Util.getImageNameOrPlaceHolder(withX: storedImage),
+                pieceName: pieceName,
+                quantity: quantity,
+                officialColour: colour
+            )
+            
+            legoPieces.append(newPiece)
+            LegoPieceDBManager.shared.addPiece(piece: newPiece)
+            
+        }
     }
     
     func deletePiece(_ piece: LegoPiece) {

--- a/MobileOgelUI/Views/AddPiecePopup.swift
+++ b/MobileOgelUI/Views/AddPiecePopup.swift
@@ -62,7 +62,7 @@ struct AddPiecePopup: View {
             
             Button(action: {
                 // create LegoPiece object and add it to the VM's legoPieces array
-                vm.addNewPiece(imageName: selectedPieceType, pieceName: ClassToNameMap.labelMapping[selectedPieceType] ?? "Unknown", quantity: quantity, color: selectedColor)
+                vm.addNewPiece(imageName: selectedPieceType, pieceName: ClassToNameMap.labelMapping[selectedPieceType] ?? "Unknown", quantity: quantity, colour: selectedColor)
                 
                 // close the popup
                 showPopup.toggle()


### PR DESCRIPTION
**Changes:**
- Previously images to added pieces with the edit feature would have a mission icon image but now the mapping is set to the correct asset (if it exists). We will need to populate our assets with all the ones we offer in a future PR. 
- There was a bug where if you add a piece that already exists with the same colour it will treat it as a separate piece in the list. It properly adds to the existing quantity now.

